### PR TITLE
Feature/font color

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for aggregating and visualising contribution activity from multiple sources.
 
-[![Contribution activity calendar](https://commitoria.thomaszahner.ch/api/calendar.svg?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb&font_colour=%23ff4500)](https://commitoria.thomaszahner.ch/calendar?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb)
+[![Contribution activity calendar](https://commitoria.thomaszahner.ch/api/calendar.svg?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb&font_colour=%23c061cb)](https://commitoria.thomaszahner.ch/calendar?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb)
 
 ✔️ GitHub
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for aggregating and visualising contribution activity from multiple sources.
 
-[![Contribution activity calendar](https://commitoria.thomaszahner.ch/api/calendar.svg?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb)](https://commitoria.thomaszahner.ch/calendar?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb)
+[![Contribution activity calendar](https://commitoria.thomaszahner.ch/api/calendar.svg?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb&font_colour=%23ff4500)](https://commitoria.thomaszahner.ch/calendar?gitlab=thomas-zahner&github=thomas-zahner&font_size=14&cell_size=20&colour_strategy=InterpolationStrategy&inactive_colour=%23f6f5f4&active_colour=%23c061cb)
 
 ✔️ GitHub
 

--- a/lib/fixtures/activity.svg
+++ b/lib/fixtures/activity.svg
@@ -8,6 +8,7 @@
             .user-contrib-text {
                 font-size: 11px;
                 font-family: "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+                fill: #3a383f;
             }
         </style>
     <g transform="translate(6, 17)" data-testid="user-contrib-cell-group">

--- a/lib/fixtures/activity.svg
+++ b/lib/fixtures/activity.svg
@@ -8,7 +8,7 @@
             .user-contrib-text {
                 font-size: 11px;
                 font-family: "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-                fill: #3a383f;
+                fill: #3a383fff;
             }
         </style>
     <g transform="translate(6, 17)" data-testid="user-contrib-cell-group">

--- a/lib/src/svg/svg_renderer.rs
+++ b/lib/src/svg/svg_renderer.rs
@@ -47,10 +47,7 @@ impl TryFrom<Builder> for SvgRenderer {
 
         let font_colour = match value.font_colour {
             None => FONT_COLOUR_DEFAULT,
-            Some(colour) => match Rgba::try_from(colour) {
-                Ok(result) => result,
-                Err(err) => Err(BuilderError::InvalidRgbaValue(err))?,
-            },
+            Some(colour) => Rgba::try_from(colour).map_err(BuilderError::InvalidRgbaValue)?,
         };
 
         let colour_strategy = match value.colour_strategy.as_ref().map(|s| s.as_str()) {

--- a/web/src/query.rs
+++ b/web/src/query.rs
@@ -10,6 +10,7 @@ pub(crate) struct CalendarQuery {
     active_colour: Option<String>,
     inactive_colour: Option<String>,
     repositories: Option<Vec<String>>,
+    font_colour: Option<String>,
 }
 
 pub(crate) struct Repositories {
@@ -54,6 +55,7 @@ impl From<CalendarQuery> for svg_renderer::Builder {
             font_size: query.font_size,
             active_colour: query.active_colour,
             inactive_colour: query.inactive_colour,
+            font_colour: query.font_colour
         }
     }
 }

--- a/web/static/gitlab-calendar/form.js
+++ b/web/static/gitlab-calendar/form.js
@@ -9,14 +9,14 @@ function colourStrategyChange(e) {
   const activeColourInput = activeColour.querySelector("input");
 
   if (colourStrategy.value === "InterpolationStrategy") {
-    inactiveColour.style.display = "unset";
-    activeColour.style.display = "unset";
+    inactiveColour.classList.remove('hidden');
+    activeColour.classList.remove('hidden');
 
     inactiveColourInput.setAttribute("name", "inactive_colour");
     activeColourInput.setAttribute("name", "active_colour");
   } else {
-    inactiveColour.style.display = "none";
-    activeColour.style.display = "none";
+    inactiveColour.classList.add('hidden');
+    activeColour.classList.add('hidden');
 
     inactiveColourInput.removeAttribute("name");
     activeColourInput.removeAttribute("name");

--- a/web/static/gitlab-calendar/index.html
+++ b/web/static/gitlab-calendar/index.html
@@ -7,10 +7,9 @@
     </head>
     <body>
         <h1>Commitoria</h1>
-        <form action="/calendar" onsubmit="onSubmit(event)">
+        <form action="/calendar" class="configuration-form" onsubmit="onSubmit(event)">
             <h2>Sources</h2>
             <input type="text" name="github" placeholder="GitHub username" />
-            <br />
 
             <h3>Repositories</h3>
             <p>Add repositories by username and URL or type.</p>
@@ -31,7 +30,6 @@
                 placeholder="Font size in pixels"
                 min="3"
             />
-            <br />
 
             <input
                 type="number"
@@ -39,7 +37,6 @@
                 placeholder="Cell size in pixels"
                 min="3"
             />
-            <br />
 
             <select
                 id="colour_strategy"
@@ -51,9 +48,8 @@
                     Interpolated colour scheme
                 </option>
             </select>
-            <br />
 
-            <label id="inactive_colour">
+            <label id="inactive_colour" class="hidden">
                 Inactive colour
                 <input
                     value="#f6f5f4"
@@ -61,9 +57,8 @@
                     placeholder="Inactive colour"
                 />
             </label>
-            <br />
 
-            <label id="active_colour">
+            <label id="active_colour" class="hidden">
                 Active colour
                 <input
                     value="#c061cb"
@@ -71,8 +66,14 @@
                     placeholder="Active colour"
                 />
             </label>
-            <br />
-
+            <label for="font_colour">
+                Font colour
+                <input
+                        type="color"
+                        id="font_colour"
+                        value="#c061cb"
+                        name="font_colour"/>
+            </label>
             <input type="submit" value="Show activity" />
         </form>
 
@@ -81,7 +82,7 @@
                 >Powered by
                 <a href="https://github.com/thomas-zahner/commitoria/"
                     >Commitoria</a
-                ></small
+                ></small>
         </footer>
 
         <template id="repository-type">

--- a/web/static/gitlab-calendar/main.css
+++ b/web/static/gitlab-calendar/main.css
@@ -3,10 +3,6 @@ body {
     font-family: "Noto Sans", Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
-form {
-    margin-top: 3em;
-}
-
 input,
 select {
     padding: 10px;
@@ -69,11 +65,6 @@ input[type="submit"] {
     }
 }
 
-#inactive_colour,
-#active_colour {
-    display: none;
-}
-
 footer {
     position: fixed;
     bottom: 0.5em;
@@ -84,4 +75,36 @@ a {
     color: black;
     font-weight: bold;
     text-decoration: none;
+}
+
+.configuration-form{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    & {
+        label, select, input{
+            box-sizing: content-box;
+            max-width: 15rem;
+            margin-bottom: 0.5rem;
+        }
+
+        input[type=number],
+        input[type=text],
+        select{
+            width: 100%;
+        }
+
+        label:has(>input[type=color]){
+            display:flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+            width:100%;
+
+            &.hidden{
+                display: none;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added a query parameter for `font_colour` and updated svg_renderer to add a `fill` attribute to the svg's `<style>`.
Also updated the Readme to include an example with a purple font_colour, similar to the active_colour. (works fine for light and dark mode)

![image](https://github.com/user-attachments/assets/4ac52990-a804-4084-8b18-be3d85b5a102)
![image](https://github.com/user-attachments/assets/515593dd-ce47-4705-9c11-68aacc04d27e)

Closes #10
