### PR TITLE
Replace JS tooltip with title element

### DIFF
--- a/lib/fixtures/activity.svg
+++ b/lib/fixtures/activity.svg
@@ -12,477 +12,477 @@
             }
         </style>
     <g transform="translate(6, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-17" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-13</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-14</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-15</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-16</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-17</title></rect>
 </g>
 <g transform="translate(22, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-24" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-18</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-19</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-20</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-21</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-22</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-23</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-24</title></rect>
 </g>
 <g transform="translate(38, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2023-12-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2023-12-31" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-25</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-26</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-27</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-28</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-29</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2023-12-30</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2023-12-31</title></rect>
 </g>
 <g transform="translate(54, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-01-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-07" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-01</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-02</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-03</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-04</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-01-05</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-06</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-07</title></rect>
 </g>
 <g transform="translate(70, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-01-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-01-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-01-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-14" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-01-08</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-09</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-10</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-11</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-01-12</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-01-13</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-14</title></rect>
 </g>
 <g transform="translate(86, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-21" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-15</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-16</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-17</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-18</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-19</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-20</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-21</title></rect>
 </g>
 <g transform="translate(102, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-28" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-22</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-23</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-24</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-25</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-26</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-27</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-28</title></rect>
 </g>
 <g transform="translate(118, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-01-31" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-04" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-29</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-30</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-01-31</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-01</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-02</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-03</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-04</title></rect>
 </g>
 <g transform="translate(134, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-11" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-05</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-06</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-07</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-08</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-09</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-10</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-11</title></rect>
 </g>
 <g transform="translate(150, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-18" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-12</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-13</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-14</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-15</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-16</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-17</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-18</title></rect>
 </g>
 <g transform="translate(166, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-25" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-19</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-20</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-21</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-22</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-23</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-24</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-25</title></rect>
 </g>
 <g transform="translate(182, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-02-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-03" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-26</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-27</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-28</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-02-29</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-01</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-02</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-03</title></rect>
 </g>
 <g transform="translate(198, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="4 contributions" data-date="2024-03-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-03-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-03-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-10" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-04</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>4 contributions on 2024-03-05</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-03-06</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-07</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-03-08</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-09</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-10</title></rect>
 </g>
 <g transform="translate(214, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-03-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-03-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="4 contributions" data-date="2024-03-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-03-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-03-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-17" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-03-11</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-03-12</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>4 contributions on 2024-03-13</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-03-14</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-03-15</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-16</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-17</title></rect>
 </g>
 <g transform="translate(230, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-03-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-03-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-24" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-18</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-19</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-03-20</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-21</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-03-22</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-23</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-24</title></rect>
 </g>
 <g transform="translate(246, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-03-31" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-25</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-26</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-27</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-28</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-29</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-30</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-03-31</title></rect>
 </g>
 <g transform="translate(262, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="4 contributions" data-date="2024-04-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-07" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-01</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-02</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-03</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-04</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>4 contributions on 2024-04-05</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-06</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-07</title></rect>
 </g>
 <g transform="translate(278, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-14" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-08</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-09</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-10</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-11</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-12</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-13</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-14</title></rect>
 </g>
 <g transform="translate(294, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-04-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-04-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-04-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="7 contributions" data-date="2024-04-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-21" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-15</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-04-16</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-04-17</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-04-18</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>7 contributions on 2024-04-19</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-20</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-21</title></rect>
 </g>
 <g transform="translate(310, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="4 contributions" data-date="2024-04-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="5 contributions" data-date="2024-04-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="7 contributions" data-date="2024-04-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-04-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-28" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>4 contributions on 2024-04-22</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-23</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>5 contributions on 2024-04-24</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>7 contributions on 2024-04-25</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-26</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-04-27</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-28</title></rect>
 </g>
 <g transform="translate(326, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="9 contributions" data-date="2024-04-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-04-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-05" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>9 contributions on 2024-04-29</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-04-30</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-01</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-02</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-03</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-04</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-05</title></rect>
 </g>
 <g transform="translate(342, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-12" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-06</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-07</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-08</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-09</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-10</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-11</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-12</title></rect>
 </g>
 <g transform="translate(358, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-05-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-05-19" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-13</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-14</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-05-15</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-16</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-17</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-18</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-05-19</title></rect>
 </g>
 <g transform="translate(374, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-05-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-26" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-20</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-05-21</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-22</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-23</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-24</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-25</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-26</title></rect>
 </g>
 <g transform="translate(390, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-05-31" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-02" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-27</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-28</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-29</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-30</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-05-31</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-01</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-02</title></rect>
 </g>
 <g transform="translate(406, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-09" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-03</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-04</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-05</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-06</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-07</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-08</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-09</title></rect>
 </g>
 <g transform="translate(422, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-06-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-16" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-06-10</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-11</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-12</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-13</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-14</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-15</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-16</title></rect>
 </g>
 <g transform="translate(438, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-23" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-17</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-18</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-19</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-20</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-21</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-22</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-23</title></rect>
 </g>
 <g transform="translate(454, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-06-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-06-30" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-06-24</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-25</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-26</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-27</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-28</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-29</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-06-30</title></rect>
 </g>
 <g transform="translate(470, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-07" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-01</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-02</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-03</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-04</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-05</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-06</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-07</title></rect>
 </g>
 <g transform="translate(486, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-14" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-08</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-09</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-10</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-11</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-12</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-13</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-14</title></rect>
 </g>
 <g transform="translate(502, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-21" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-15</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-16</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-17</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-18</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-19</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-20</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-21</title></rect>
 </g>
 <g transform="translate(518, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-28" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-22</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-23</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-24</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-25</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-26</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-27</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-28</title></rect>
 </g>
 <g transform="translate(534, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-07-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-07-31" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-04" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-29</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-07-30</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-07-31</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-01</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-02</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-03</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-04</title></rect>
 </g>
 <g transform="translate(550, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-08-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-11" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-08-05</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-06</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-07</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-08</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-09</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-10</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-11</title></rect>
 </g>
 <g transform="translate(566, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-08-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-08-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-18" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-12</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-13</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-08-14</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-15</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-08-16</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-17</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-18</title></rect>
 </g>
 <g transform="translate(582, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-08-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="9 contributions" data-date="2024-08-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-08-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-25" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-19</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-08-20</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-21</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>9 contributions on 2024-08-22</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-23</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-08-24</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-25</title></rect>
 </g>
 <g transform="translate(598, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="5 contributions" data-date="2024-08-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-08-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="5 contributions" data-date="2024-08-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-08-31" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-01" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>5 contributions on 2024-08-26</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-08-27</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-28</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>5 contributions on 2024-08-29</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-30</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-08-31</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-01</title></rect>
 </g>
 <g transform="translate(614, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-09-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-08" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-02</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-03</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-04</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-05</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-06</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-09-07</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-08</title></rect>
 </g>
 <g transform="translate(630, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-09-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-09-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="6 contributions" data-date="2024-09-15" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-09-09</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-10</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-11</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-12</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-13</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-09-14</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>6 contributions on 2024-09-15</title></rect>
 </g>
 <g transform="translate(646, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-09-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="5 contributions" data-date="2024-09-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-09-22" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-16</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-17</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-18</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-09-19</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>5 contributions on 2024-09-20</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-21</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-09-22</title></rect>
 </g>
 <g transform="translate(662, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-29" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-23</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-24</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-25</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-26</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-27</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-28</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-29</title></rect>
 </g>
 <g transform="translate(678, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-09-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="5 contributions" data-date="2024-10-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-10-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#7992f5ff" data-hover-info="13 contributions" data-date="2024-10-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="6 contributions" data-date="2024-10-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="4 contributions" data-date="2024-10-06" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-09-30</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-01</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>5 contributions on 2024-10-02</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-10-03</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#7992f5ff" class="user-contrib-cell has-tooltip"><title>13 contributions on 2024-10-04</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>6 contributions on 2024-10-05</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>4 contributions on 2024-10-06</title></rect>
 </g>
 <g transform="translate(694, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-10-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-13" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-07</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-08</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-09</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-10</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-11</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-10-12</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-13</title></rect>
 </g>
 <g transform="translate(710, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-17" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="3 contributions" data-date="2024-10-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-10-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-20" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-14</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-15</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-16</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-17</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>3 contributions on 2024-10-18</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-10-19</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-20</title></rect>
 </g>
 <g transform="translate(726, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-10-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-10-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-24" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-27" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-21</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-10-22</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-10-23</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-24</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-25</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-26</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-27</title></rect>
 </g>
 <g transform="translate(742, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-10-31" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-01" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-03" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-28</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-29</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-30</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-10-31</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-01</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-02</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-03</title></rect>
 </g>
 <g transform="translate(758, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-11-08" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="8 contributions" data-date="2024-11-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-10" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-04</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-05</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-06</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-07</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-11-08</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>8 contributions on 2024-11-09</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-10</title></rect>
 </g>
 <g transform="translate(774, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-13" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-14" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-15" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-16" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-17" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-11</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-12</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-13</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-14</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-15</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-16</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-17</title></rect>
 </g>
 <g transform="translate(790, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-18" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-19" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-20" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-21" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-22" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-23" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-11-24" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-18</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-19</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-20</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-21</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-22</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-23</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-11-24</title></rect>
 </g>
 <g transform="translate(806, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-25" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-26" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-27" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-28" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-11-29" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-11-30" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-01" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-25</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-26</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-27</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-28</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-11-29</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-11-30</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-01</title></rect>
 </g>
 <g transform="translate(822, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-08" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-02</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-03</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-04</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-05</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-06</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-07</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-08</title></rect>
 </g>
 <g transform="translate(838, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-09" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-12-10" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-11" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-12-12" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-13" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-09</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-12-10</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-11</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-12-12</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-13</title></rect>
 </g>
 <g direction="ltr"><text x="6" y="11" class="user-contrib-text">Dec</text>
 <text x="54" y="11" class="user-contrib-text">Jan</text>

--- a/lib/fixtures/week_group.svg
+++ b/lib/fixtures/week_group.svg
@@ -1,9 +1,9 @@
 <g transform="translate(6, 17)" data-testid="user-contrib-cell-group">
-<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-02" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-03" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="1 contribution" data-date="2024-12-04" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" data-hover-info="2 contributions" data-date="2024-12-05" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#7992f5ff" data-hover-info="17 contributions" data-date="2024-12-06" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-07" class="user-contrib-cell has-tooltip"></rect>
-<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" data-hover-info="No contributions" data-date="2024-12-08" class="user-contrib-cell has-tooltip"></rect>
+<rect x="0" y="0" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-02</title></rect>
+<rect x="0" y="16" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-03</title></rect>
+<rect x="0" y="32" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>1 contribution on 2024-12-04</title></rect>
+<rect x="0" y="48" rx="2" ry="2" width="14" height="14" fill="#d2dcffff" class="user-contrib-cell has-tooltip"><title>2 contributions on 2024-12-05</title></rect>
+<rect x="0" y="64" rx="2" ry="2" width="14" height="14" fill="#7992f5ff" class="user-contrib-cell has-tooltip"><title>17 contributions on 2024-12-06</title></rect>
+<rect x="0" y="80" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-07</title></rect>
+<rect x="0" y="96" rx="2" ry="2" width="14" height="14" fill="#ececefff" class="user-contrib-cell has-tooltip"><title>No contributions on 2024-12-08</title></rect>
 </g>

--- a/lib/src/svg/svg_renderer.rs
+++ b/lib/src/svg/svg_renderer.rs
@@ -128,7 +128,7 @@ impl SvgRenderer {
     }
 
     fn render_at(&self, activity: &ContributionActivity, last_day: NaiveDate) -> String {
-        let mut result: Vec<Vec<Data>> = vec![]; // todo: functional instead of this weird imperative style
+        let mut result: Vec<Vec<Data>> = vec![]; // TODO: functional instead of this weird imperative style
         let mut months: Vec<MonthText> = vec![];
         let mut day = last_day.clone() - YEAR;
 
@@ -218,7 +218,7 @@ impl SvgRenderer {
     fn render_week_day_cells(&self, days: Vec<Data>, average_count_per_day: f32) -> String {
         let cell_size: usize = self.cell_size;
         const CELL_RADIUS: usize = 2;
-        const FIST_DAY_OF_WEEK: usize = 0; // todo
+        const FIST_DAY_OF_WEEK: usize = 0; // TODO: make configurable?
 
         days.into_iter()
             .map(|day| {
@@ -229,13 +229,14 @@ impl SvgRenderer {
                 });
 
                 let y = self.day_size_with_space * ((day.date.weekday().num_days_from_monday() as usize + 7 - FIST_DAY_OF_WEEK) % 7);
-                let data_date = day.date.to_string();
                 let colour = self.colour_strategy.get_colour(ContributionInfo {
                     average_count_per_day,
                     count_today: day.count,
                 });
 
-                format!(r#"<rect x="0" y="{y}" rx="{CELL_RADIUS}" ry="{CELL_RADIUS}" width="{cell_size}" height="{cell_size}" fill="{colour}" data-hover-info="{hover_info}" data-date="{data_date}" class="user-contrib-cell has-tooltip"></rect>"#)
+                let title = format!("{hover_info} on {}", day.date); // TODO: i18n date according to request headers?
+                let content = format!("<title>{}</title>", title);
+                format!(r#"<rect x="0" y="{y}" rx="{CELL_RADIUS}" ry="{CELL_RADIUS}" width="{cell_size}" height="{cell_size}" fill="{colour}" class="user-contrib-cell has-tooltip">{content}</rect>"#)
             })
             .collect::<Vec<_>>()
             .join("\n")

--- a/web/static/gitlab-calendar/calendar.html
+++ b/web/static/gitlab-calendar/calendar.html
@@ -6,8 +6,6 @@
         <link rel="stylesheet" type="text/css" href="main.css" />
     </head>
     <body>
-        <div id="popup"></div>
-
         <div class="activities-block">
             <h2>Activity</h2>
 

--- a/web/static/gitlab-calendar/calendar.js
+++ b/web/static/gitlab-calendar/calendar.js
@@ -31,32 +31,6 @@ async function fetchData(url) {
   calendar.scrollLeft = calendar.scrollWidth;
 }
 
-function showPopup(event, textContent) {
-  const popup = document.querySelector("#popup");
-  const pixelsAboveCursor = 30;
-  Object.assign(popup.style, {
-    left: `${event.clientX + window.scrollX}px`,
-    top: `${event.clientY + window.scrollY - pixelsAboveCursor}px`,
-    display: "block",
-  });
-
-  popup.textContent = textContent;
-}
-
-function hidePopup() {
-  const popup = document.querySelector("#popup");
-  popup.style.display = "none";
-}
-
-function whenUserContribCell(event, then) {
-  const target = event.target;
-  const list = target.classList;
-
-  if (list.contains("user-contrib-cell") && list.contains("has-tooltip")) {
-    then();
-  }
-}
-
 function setupUrlSection(url) {
   const svgUrlInput = document.querySelector("input#svg-url");
   svgUrlInput.onclick = (e) => e.target.select();
@@ -66,26 +40,6 @@ function setupUrlSection(url) {
   markdownInput.onclick = (e) => e.target.select();
   markdownInput.value = `[![Contribution activity calendar](${url.href})](${location.href})`;
 }
-
-function extractPopupMessage(event) {
-  const target = event.target;
-  const date = target.getAttribute("data-date");
-  let textContent = target.getAttribute("data-hover-info");
-
-  if (date) {
-    textContent += " on " + date;
-  }
-
-  return textContent;
-}
-
-addEventListener("mouseover", (event) => {
-  whenUserContribCell(event, () =>
-    showPopup(event, extractPopupMessage(event)),
-  );
-});
-
-addEventListener("mouseout", (event) => whenUserContribCell(event, hidePopup));
 
 const url = constructUrl();
 setupUrlSection(url);

--- a/web/static/gitlab-calendar/form.js
+++ b/web/static/gitlab-calendar/form.js
@@ -23,7 +23,11 @@ function colourStrategyChange(e) {
   }
 }
 
-function addRepositoryLine() {
+function addBareRepositoryLine() {
+  repositories.appendChild(createRepositoryLine());
+}
+
+function createRepositoryLine() {
   const repository = document.createElement("div");
 
   const username = document.createElement("input");
@@ -52,7 +56,7 @@ function addRepositoryLine() {
   repository.appendChild(type);
   repository.appendChild(deleteButton);
 
-  repositories.appendChild(repository);
+  return repository;
 }
 
 function onSubmit(event) {

--- a/web/static/gitlab-calendar/main.css
+++ b/web/static/gitlab-calendar/main.css
@@ -51,12 +51,6 @@ input[type="submit"] {
     text-align: center;
 }
 
-#popup {
-    position: absolute;
-    display: none;
-    background: gold;
-}
-
 #svg-url-section {
     margin-top: 2em;
 
@@ -77,32 +71,34 @@ a {
     text-decoration: none;
 }
 
-.configuration-form{
+.configuration-form {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     & {
-        label, select, input{
+        label,
+        select,
+        input {
             box-sizing: content-box;
             max-width: 15rem;
             margin-bottom: 0.5rem;
         }
 
-        input[type=number],
-        input[type=text],
-        select{
+        input[type="number"],
+        input[type="text"],
+        select {
             width: 100%;
         }
 
-        label:has(>input[type=color]){
-            display:flex;
+        label:has(> input[type="color"]) {
+            display: flex;
             flex-direction: row;
             justify-content: space-between;
             align-items: center;
-            width:100%;
+            width: 100%;
 
-            &.hidden{
+            &.hidden {
                 display: none;
             }
         }


### PR DESCRIPTION
Closes #12 

Note that I fully remove the JS tooltip with this PR. This is because I didn't like it very much code-wise and UX-wise.
Also the user should be able to get more information when clicking on a day as reported in #14.